### PR TITLE
Fixed the default commodity_info bug

### DIFF
--- a/src/nft.rs
+++ b/src/nft.rs
@@ -53,10 +53,10 @@ pub trait UniqueAssets<AccountId> {
     /// Destroy an asset.
     /// This method **must** return an error in the following case:
     /// - The asset with the specified ID does not exist.
-    fn burn(asset_id: &Self::AssetId) -> DispatchResult;
+    fn burn(asset_id: &Self::AssetId, asset_info: &Self::AssetInfo) -> DispatchResult;
     /// Transfer ownership of an asset to another account.
     /// This method **must** return an error in the following cases:
     /// - The asset with the specified ID does not exist.
     /// - The destination account has already reached the user asset limit.
-    fn transfer(dest_account: &AccountId, asset_id: &Self::AssetId) -> DispatchResult;
+    fn transfer(dest_account: &AccountId, asset_id: &Self::AssetId, asset_info: &Self::AssetInfo) -> DispatchResult;
 }


### PR DESCRIPTION
In the pallet's "src/lib.rs" where the "nft::UniqueAssets" trait is implemented, both the burn and the transfer methods have a bug.
The problem is that when creating an instance of the tuple representing the commodity (lines 271 & 302) to be used for searching the storage, the default value is used, i.e., "<T as Trait<I>>::CommodityInfo::default()". Due to this when ever the burn or transfer methods are called the search fails with a panic. This bug is not caught by the tests, as the tests themselves use default values. 

This bug was fixed by adding the commodity_info as an input to the extrinsic call. This approach was taken to fix the bug with minimal changes to the underlying logic, and is hence not an ideal solution.